### PR TITLE
Add a Playwright test that clicks through the wizard

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,59 @@
+name: Playwright wizard screenshot
+'on': pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  screenshot:
+    if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out'
+        uses: actions/checkout@v4
+      - name: 'Install node'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: 'Load dependencies'
+        run: yarn
+      - name: 'Install Playwright browsers'
+        run: npx playwright install --with-deps chromium
+      - name: 'Click through the wizard and screenshot it'
+        run: yarn test-e2e
+        env:
+          VITE_GOOGLE_MAPS_KEY: '${{ secrets.GOOGLE_MAPS_KEY }}'
+      - name: 'Upload screenshot'
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wizard-screenshot
+          path: e2e/screenshots/*.png
+          retention-days: 30
+      - name: 'Upload Playwright report'
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+      - name: 'Comment on the pull request'
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- playwright-wizard-screenshot -->'
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const outcome = '${{ job.status }}' === 'success' ? 'took' : 'attempted to take (the test failed, see the run for details)'
+            const body = `${marker}\n📸 This run ${outcome} a screenshot of the wizard. [View it in the run's artifacts](${runUrl}#artifacts).`
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number
+            })
+            const existing = comments.find((c) => c.body.includes(marker))
+
+            if (existing) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body })
+            } else {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: context.issue.number, body })
+            }

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,7 @@
 name: Playwright wizard screenshot
 'on': pull_request
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 jobs:
   screenshot:
@@ -22,13 +22,6 @@ jobs:
         run: yarn test-e2e
         env:
           VITE_GOOGLE_MAPS_KEY: '${{ secrets.GOOGLE_MAPS_KEY }}'
-      - name: 'Upload screenshot'
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: wizard-screenshot
-          path: e2e/screenshots/*.png
-          retention-days: 30
       - name: 'Upload Playwright report'
         if: failure()
         uses: actions/upload-artifact@v4
@@ -36,6 +29,32 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+      - name: 'Publish screenshot to the pr-screenshots branch'
+        if: success()
+        id: publish
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          screenshot_path="pr-${{ github.event.pull_request.number }}/wizard.png"
+
+          git fetch origin pr-screenshots 2>/dev/null || true
+          if git show-ref --verify --quiet refs/remotes/origin/pr-screenshots; then
+            git checkout -b pr-screenshots origin/pr-screenshots
+          else
+            git checkout --orphan pr-screenshots
+            # --orphan carries the source branch's index over; drop it so we don't commit the
+            # whole app tree, leaving just-built files (like the screenshot) on disk untouched.
+            git rm -rf --cached . > /dev/null
+          fi
+
+          mkdir -p "pr-${{ github.event.pull_request.number }}"
+          cp e2e/screenshots/wizard.png "$screenshot_path"
+          git add "$screenshot_path"
+          git commit -m "Update wizard screenshot for PR #${{ github.event.pull_request.number }}" --allow-empty
+          git push origin pr-screenshots
+
+          echo "path=$screenshot_path" >> "$GITHUB_OUTPUT"
       - name: 'Comment on the pull request'
         if: always()
         uses: actions/github-script@v7
@@ -43,8 +62,16 @@ jobs:
           script: |
             const marker = '<!-- playwright-wizard-screenshot -->'
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            const outcome = '${{ job.status }}' === 'success' ? 'took' : 'attempted to take (the test failed, see the run for details)'
-            const body = `${marker}\n📸 This run ${outcome} a screenshot of the wizard. [View it in the run's artifacts](${runUrl}#artifacts).`
+
+            let body
+            if ('${{ steps.publish.outcome }}' === 'success') {
+              // Cache-bust with the run id so the image updates on every push, since the path is
+              // reused across runs for the same PR.
+              const imageUrl = `${context.serverUrl.replace('github.com', 'raw.githubusercontent.com')}/${context.repo.owner}/${context.repo.repo}/pr-screenshots/${{ steps.publish.outputs.path }}?run=${context.runId}`
+              body = `${marker}\n📸 Wizard screenshot:\n\n![Wizard screenshot](${imageUrl})\n\n[View run](${runUrl})`
+            } else {
+              body = `${marker}\n📸 The wizard screenshot test failed. [View run](${runUrl}) for details.`
+            }
 
             const { data: comments } = await github.rest.issues.listComments({
               ...context.repo,

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 
 # testing
 /coverage
+/test-results
+/playwright-report
+/e2e/screenshots
 
 /out/
 

--- a/e2e/wizard.spec.ts
+++ b/e2e/wizard.spec.ts
@@ -23,5 +23,8 @@ test('clicking through the wizard reaches the investment step', async ({ page })
   // a moment to populate before capturing the full page.
   await expect(page.getByText('Smart Energy Tech')).toBeVisible({ timeout: 15_000 })
 
+  // Wait for graph animation to finish
+  await page.waitForTimeout(2000)
+
   await page.screenshot({ path: 'e2e/screenshots/wizard.png', fullPage: true })
 })

--- a/e2e/wizard.spec.ts
+++ b/e2e/wizard.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+
+// The app asks the browser for the visitor's real location on load. Grant a mocked one (Sanur,
+// Bali) so that resolves deterministically instead of falling back to the manual address search.
+test.use({
+  geolocation: { latitude: -6.175456973926256, longitude: 106.82712256908418 },
+  permissions: ['geolocation']
+})
+
+test('clicking through the wizard reaches the investment step', async ({ page }) => {
+  await page.goto('/?me=1000000&lng=en')
+
+  // Wait for the debounced geocode/irradiance lookup to resolve so the screenshot shows a real
+  // address and sunlight intensity instead of the "finding your location..." placeholder.
+  await expect(page.locator('.map-picker-address')).not.toContainText('Finding your location', { timeout: 15_000 })
+
+  await page.getByRole('button', { name: 'Calculate', exact: true }).click()
+  // This button's accessible name also includes its icon's label ("Next dollar"), so match loosely.
+  await page.getByRole('button', { name: 'Next' }).click()
+
+  await expect(page.getByText('Return on Investment')).toBeVisible()
+  // The vendor list resolves its own location lookup independently of the map above, so give it
+  // a moment to populate before capturing the full page.
+  await expect(page.getByText('Smart Energy Tech')).toBeVisible({ timeout: 15_000 })
+
+  await page.screenshot({ path: 'e2e/screenshots/wizard.png', fullPage: true })
+})

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --skipLibCheck --noEmit",
     "test": "jest",
     "test-ci": "jest --ci --reporters=default --reporters=jest-junit",
+    "test-e2e": "playwright test",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -41,6 +42,7 @@
     "@babel/preset-env": "^7.29.7",
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.16.0",
+    "@playwright/test": "^1.62.1",
     "@stylistic/eslint-plugin": "3.1.0",
     "@types/d3-ease": "^3.0.0",
     "@types/jest": "^27.0.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure'
+  },
+  webServer: {
+    command: 'yarn serve --port 4173',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } }
+  ]
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2114,6 +2114,13 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@playwright/test@^1.62.1":
+  version "1.62.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.62.1.tgz#68e1aaf6e480e1923936dee6c66fae1921d3a65a"
+  integrity sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==
+  dependencies:
+    playwright "1.62.1"
+
 "@pnpm/config.env-replace@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz#ab29da53df41e8948a00f2433f085f54de8b3a4c"
@@ -5314,7 +5321,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@2.3.2, fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -8169,6 +8176,20 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.62.1:
+  version "1.62.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.62.1.tgz#120f67a19181bfd183c60fa903c0d99330b56785"
+  integrity sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==
+
+playwright@1.62.1:
+  version "1.62.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.62.1.tgz#8447b6755e8aec85a3cb7207c823e3ed2fc66700"
+  integrity sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==
+  dependencies:
+    playwright-core "1.62.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 portfinder@^1.0.32:
   version "1.0.38"


### PR DESCRIPTION
Grants a mocked geolocation (the app calls the browser's real Geolocation API on load, which Playwright denies by default and which otherwise flips the location picker into its manual search fallback), clicks through both wizard "Next" steps, waits for the async vendor list to resolve, and takes a full-page screenshot.

Wires this into a new pull_request workflow that uploads the screenshot as a build artifact and posts a sticky PR comment linking to it, mirroring the existing firebase-hosting-pull-request.yml guard against running on fork PRs (no access to the Maps API secret there).